### PR TITLE
Fixed Phil/Pegasus Mismatch

### DIFF
--- a/msg/he.yml
+++ b/msg/he.yml
@@ -3,8 +3,14 @@
 
 - id: 0x1D60
   en: "The Phil Cup trophy."
+  fr: "Le trophée de la coupe Philoctète."
   gr: "Der Phil-Cup-Pokal."
+  it: "Il trofeo della Coppa Fil."
+  sp: "El trofeo de la Copa Fil."
 
 - id: 0x1D61
   en: "The Pegasus Cup shield."
+  fr: "Le trophée de la coupe Pégase."
   gr: "Der Pegasus-Cup-Schild."
+  it: "Lo scudo della Coppa Pegaso."
+  sp: "El escudo de la Copa Pegaso."

--- a/msg/sys.yml
+++ b/msg/sys.yml
@@ -366,7 +366,7 @@
   gr: "{:icon question-mark}{:color #FF010180}FRAGE{:reset}
 
 
-    {:width 90}Es neues Update für Re:Fined wurde entdeckt!
+    {:width 90}Ein neues Update für Re:Fined wurde entdeckt!
 
     Neue Updates bieten meistens mehr Stabilität.
     


### PR DESCRIPTION
Fixes the error in the original game where the descriptions of the Phil Cup Trophy and the Pegasus Cup Shield are mixed up. Fixed for MULTI5 languages.

The Goddess of the Fate Cup trophy is correct in the other languages, so no changes needed here.