### PR TITLE
FR: minor changes

### DIFF
--- a/textfiles/hb.yml
+++ b/textfiles/hb.yml
@@ -9,7 +9,7 @@
     {:unk 15}{:unk 33}{:unk 00}Ahora no.
     
     {:unk 15}{:unk 00}{:unk 13}¡A batirse tocan!"
-  fr: "{:unk 08}{:unk 02}{:unk 00}{:unk 06}Combattre Séphiroth à nouveau?
+  fr: "{:unk 08}{:unk 02}{:unk 00}{:unk 06}Combattre Séphiroth à nouveau ?
   
     {:unk 15}{:unk 33}{:unk 00}Pas maintenant.
 

--- a/textfiles/hb.yml
+++ b/textfiles/hb.yml
@@ -13,7 +13,7 @@
   
     {:unk 15}{:unk 33}{:unk 00}Pas maintenant.
 
-    {:unk 15}{:unk 00}{:unk 13}Je suis prêt à me battre!"
+    {:unk 15}{:unk 00}{:unk 13}Je suis prêt à me battre !"
   gr: "{:unk 08}{:unk 02}{:unk 00}{:unk 06}Möchtest du dich mit Sephiroth messen?
   
     {:unk 15}{:unk 33}{:unk 00}Das lass ich lieber.

--- a/textfiles/sys.yml
+++ b/textfiles/sys.yml
@@ -98,7 +98,7 @@
   en: "Silent"
   it: "Silenzioso"
   gr: "Unbemerkt"
-  fr: "Silencieux"
+  fr: "Silencieuse"
   sp: "Silencioso"
 
 - id: 0x5708
@@ -114,7 +114,7 @@
   en: "Disabled"
   it: "Disattivato"
   gr: "Deaktiviert"
-  fr: "Désactivé"
+  fr: "Désactivée"
   sp: "Desactivado"
 
 - id: 0x570A
@@ -329,7 +329,7 @@
 
     apparence venue d'un lieu familier
 
-    mais enigmatique."
+    mais énigmatique."
   gr: "Benutze ein Kommando-Menü, das an eine Zeit
 
     und einen Ort erinnert, doch dabei so
@@ -497,7 +497,7 @@
   
 - id: 0x5744
   en: "On Recharge!"
-  fr: "En Recharge!"
+  fr: "En Recharge !"
   it: "In Ricarica!"
   sp: "¡En recarga!"
   gr: "Beim Aufladen!"
@@ -698,7 +698,7 @@
     kannst du mittels des Drive-Kommandos
     
     in die Anti-Form wechseln."
-  fr: "En utilisant les ténèbres du coeur de Sora,
+  fr: "En utilisant les ténèbres du cæur de Sora,
     
     utilisez le menu de Fusion pour utiliser
     
@@ -739,21 +739,21 @@
   en: "Dodge Roll LV1"
   it: "Destrezza I"
   gr: "Ausweichrolle LV. 1"
-  fr: "Roulade LV1"
+  fr: "Roulade Niv. 1"
   sp: "Voltereta 1"
   
 - id: 0x4E85
   en: "Dodge Roll LV2"
   it: "Destrezza II"
   gr: "Ausweichrolle LV. 2"
-  fr: "Roulade LV2"
+  fr: "Roulade Niv. 2"
   sp: "Voltereta 2"
 
 - id: 0x4E87
   en: "Dodge Roll LV3"
   it: "Destrezza III"
   gr: "Ausweichrolle LV. 3"
-  fr: "Roulade LV3"
+  fr: "Roulade Niv. 3"
   sp: "Voltereta 3"
   
 - id: 0x4E8D

--- a/textfiles/sys.yml
+++ b/textfiles/sys.yml
@@ -82,7 +82,7 @@
   en: "Informative"
   it: "Informativo"
   gr: "Informativ"
-  fr: "Informatif"
+  fr: "Informative"
   sp: "Informativo"
 
 - id: 0x5706
@@ -191,14 +191,14 @@
   en: "French"
   it: "Francese"
   gr: "Französisch"
-  fr: "Francais"
+  fr: "Français"
   sp: "Francés"
 
 - id: 0x5715
   en: "The audio will be in French."
   it: "La lingua del doppiaggio sarà in Francese."
   gr: "Die Sprachausgabe wird auf Französisch sein."
-  fr: "La langue audio sera en Francais."
+  fr: "La langue audio sera en Français."
   sp: "El idioma del audio será en francés."
   
 - id: 0x5716
@@ -509,7 +509,7 @@
   sp: "¡Has descubierto un secreto! Me pregunto que será, kupo..."
   gr: "Du hast ein Geheimnis entdeckt! Was da wohl passiert ist, kupo...?"
   it: "Hai scoperto un segreto! Mi chiedo cosa abbia fatto, kupo..."
-  fr: "Ouah ! Tu as découvert un secret ! Qu'est-ce que ca a fait, je me demande...?"
+  fr: "Ouah ! Tu as découvert un secret ! Qu'est-ce que ça a fait, je me demande...?"
   
 - id: 0x5750
   en: "Retribution"
@@ -583,7 +583,7 @@
 - id: 0x5754
   en: "Lock-On Controls"
   sp: "{:width 85}Controles de fijar objetivo"
-  fr: "{:width 90}Contrôle du verrouillage"
+  fr: "{:width 90}Contrôles du verrouillage"
 
 - id: 0x5755
   en: "Type A"


### PR DESCRIPTION
oe->æ
"sauvegarde" is feminine
accented character
spaces before exclamation point and question mark
LV->Niv.
I didn't change the "c" to "ç" because I don't know if the game can handle it